### PR TITLE
Advertise spring 2017 schedule

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,16 +14,16 @@
       </a>
 
       <div class="trigger">
-        <!-- <a class="page=link" href="/spring2015/">Talks This Semester</a> | 
+        <!-- <a class="page=link" href="/spring2015/">Talks This Semester</a> |
           This needs the categories plugin to work, so maybe one day.
         -->
 
-        <a class="page=link" href="http://wonks.github.io/organizational/fall2016/2016/08/26/org-meeting.html">
-        Fall 2016 Schedule</a> | 
+        <a class="page=link" href="http://wonks.github.io/organizational/spring2017/2017/01/13/org-meeting.html">
+        Spring 2017 Schedule</a> |
         <a class="page=link" href="/courses.html">Courses</a>  |
         <a class="page=link" href="/activities.html">Activities</a>  |
         <a class="page=link" href="/groups.html">Related Groups</a>  |
-        <a class="page=link" href="/talks.html">Archives</a>  
+        <a class="page=link" href="/talks.html">Archives</a>
           (<a href="/archives.html">By Category</a>)
         <!-- {% for page in site.pages %}
           {% if page.title %}

--- a/_posts/sp17/2016-01-13-org-meeting.markdown
+++ b/_posts/sp17/2016-01-13-org-meeting.markdown
@@ -3,7 +3,7 @@ layout:     post
 title:      "Semester Organizational Meeting"
 authors:    "Wonks General"
 date:       2017-01-13 04:15:00
-categories: Organizational Fall2016
+categories: Organizational Spring2017
 ---
 
 ## Description

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ layout: default
   4:15pm in Lindley Hall Room 101, and all are welcome to attend.
 
   <ul>
-    <li><a href="http://wonks.github.io/organizational/fall2016/2016/08/26/org-meeting.html">
+    <li><a href="http://wonks.github.io/organizational/spring2017/2017/01/13/org-meeting.html">
     Current talk schedule</a></li>
     <li><a href="https://list.indiana.edu/sympa/info/pl-wonks-l">pl-wonks-l</a>, our official mailing list</li>
   </ul>


### PR DESCRIPTION
Currently, the URL for the spring 2017 talk schedule is http://wonks.github.io/organizational/fall2016/2017/01/13/org-meeting.html, which is a bit hard to discover, since it lives under `fall2016` and not `spring2017`. I've corrected this.

I also put links to the new URL on the front page.

Pinging @Victorialewis